### PR TITLE
Twopass

### DIFF
--- a/Naje.md
+++ b/Naje.md
@@ -370,7 +370,7 @@ void najeAssemble(char *source) {
                 if (pass == 0) {
                   najeData(1, -9999);
                 } else {
-                  najeData(0, najeLookup((char *) token));
+                  najeData(-1, najeLookup((char *) token));
 		  najeRefCount[najeLookupPtr((char *) token)]++;
 		}
                 break;
@@ -428,7 +428,7 @@ void najeAssemble(char *source) {
       if (pass == 0) {
         najeData(1, -9999);
       } else {
-        najeData(0, najeLookup((char *) token));
+        najeData(-1, najeLookup((char *) token+1));
         najeRefCount[najeLookupPtr((char *) token)]++;
       }
     } else {

--- a/Naje.md
+++ b/Naje.md
@@ -367,11 +367,12 @@ void najeAssemble(char *source) {
     switch (relevant[1]) {
       case 'r': /* .reference */
                 token = strtok_r(ptr, " ,", &rest);
-                if (pass == 0)
+                if (pass == 0) {
                   najeData(1, -9999);
-                else
+                } else {
                   najeData(0, najeLookup((char *) token));
 		  najeRefCount[najeLookupPtr((char *) token)]++;
+		}
                 break;
       case 'c': /* .comment */
                 break;
@@ -424,11 +425,12 @@ void najeAssemble(char *source) {
     token = strtok_r(ptr, " ,", &rest);
     najeInst(1);
     if (token[0] == '&') {
-      if (pass == 0)
+      if (pass == 0) {
         najeData(1, -9999);
-      else
+      } else {
         najeData(0, najeLookup((char *) token));
         najeRefCount[najeLookupPtr((char *) token)]++;
+      }
     } else {
       najeData(0, atoi(token));
     }

--- a/Naje.md
+++ b/Naje.md
@@ -149,6 +149,7 @@ Global variables.
 | najePointers | array of pointers that go with **najeLabels**              |
 | np           | index into **najeLabels** and **najePointers**             |
 | references   | array of types used to identify references needing patched |
+| pass         | 0: first pass (references unresoled) 1: second pass        |
 
 ````
 CELL latest;
@@ -170,6 +171,8 @@ CELL najeRefCount[MAX_NAMES];
 CELL np;
 
 CELL references[IMAGE_SIZE];
+
+CELL pass;
 
 char outputName[STRING_LEN];
 
@@ -199,6 +202,8 @@ CELL najeLookupPtr(char *name) {
 
 
 void najeAddLabel(char *name, CELL slice) {
+  if (pass == 1)  // labels recorded only in 1st pass
+    return;
   if (najeLookup(name) == -1) {
     strcpy(najeLabels[np], name);
     najePointers[np] = slice;
@@ -209,48 +214,7 @@ void najeAddLabel(char *name, CELL slice) {
     exit(0);
   }
 }
-````
 
-Naje can be configured to allow for forward references. This can use a
-significant amount of RAM, so is disabled by default. To enable, compile with
--DALLOW_FORWARD_REFS
-
-````
-#ifdef ALLOW_FORWARD_REFS
-char ref_names[MAX_NAMES][STRING_LEN];
-CELL refp;
-#endif
-
-void najeAddReference(char *name) {
-#ifdef ALLOW_FORWARD_REFS
-  strcpy(ref_names[refp], name);
-  refp++;
-#endif
-}
-
-void najeResolveReferences() {
-#ifdef ALLOW_FORWARD_REFS
-  CELL offset, matched;
-  CELL i, j;
-
-  for (i = 0; i < refp; i++) {
-    offset = najeLookup(ref_names[i]);
-    matched = 0;
-    if (offset != -1) {
-        for (j = 0; j < latest; j++) {
-          if (references[j] == 1 && matched == 0) {
-            memory[j] = offset;
-            references[j] = -1;
-            najeRefCount[najeLookupPtr(ref_names[i])]++;
-            matched = -1;
-          }
-        }
-    } else {
-      printf("\nERROR: Failed to resolve a reference: %s", ref_names[i]);
-    }
-  }
-#endif
-}
 ````
 
 A *map* is a file which, along with the image file, can be used to identify
@@ -403,12 +367,11 @@ void najeAssemble(char *source) {
     switch (relevant[1]) {
       case 'r': /* .reference */
                 token = strtok_r(ptr, " ,", &rest);
-#ifdef ALLOW_FORWARD_REFS
-                najeAddReference((char *)token);
-                najeData(1, -9999);
-#else
-                najeData(0, najeLookup((char *)token));
-#endif
+                if (pass == 0)
+                  najeData(1, -9999);
+                else
+                  najeData(0, najeLookup((char *) token));
+		  najeRefCount[najeLookupPtr((char *) token)]++;
                 break;
       case 'c': /* .comment */
                 break;
@@ -461,12 +424,11 @@ void najeAssemble(char *source) {
     token = strtok_r(ptr, " ,", &rest);
     najeInst(1);
     if (token[0] == '&') {
-#ifdef ALLOW_FORWARD_REFS
-      najeAddReference((char *)token + 1);
-      najeData(1, -9999);
-#else
-      najeData(0, najeLookup((char *)token + 1));
-#endif
+      if (pass == 0)
+        najeData(1, -9999);
+      else
+        najeData(0, najeLookup((char *) token));
+        najeRefCount[najeLookupPtr((char *) token)]++;
     } else {
       najeData(0, atoi(token));
     }
@@ -524,7 +486,8 @@ void najeAssemble(char *source) {
 }
 
 void prepare() {
-  np = 0;
+  if (pass == 0)
+    np = 0;
   latest = 0;
   packMode = 1;
 
@@ -598,12 +561,19 @@ void save() {
 
 CELL main(int argc, char **argv) {
   CELL i;
+
+  pass = 0;
   prepare();
     process_file(argv[1]);
     najeSync();
-    najeResolveReferences();
+  finish();
+
+  pass = 1;
+  prepare();
+    process_file(argv[1]);
     najeSync();
   finish();
+
   save();
   najeWriteMap();
 


### PR DESCRIPTION
OK -- so, here's my idea for two-pass.

Essentially, I've done the following:
* removed ref_names (64KB), refp, najeAddReference, and najeResolveReferences
* obsoleted #define ALLOW_FORWARD_REFS
* added a global variable "pass" (0: first pass, 1: second pass)
* replaced najeAddReference/najeLookup calls with a pass check -- 1st pass write a dummy value, 2nd pass write the lookup value; this is done for &ref's and .ref's
* placed two passes in main, first with pass=0, second with pass=1
* preserved najeRefCount values, to the best of my knowledge (only casually tested)
* emulated the way that references[n] was set to 1 pre-resolution, and then -1 post-resolution, so that the map shows POINTER values, similar to the prior code

I don't have anything for heavy duty testing with -- I've only tested that the output for the samples works presently: fibonacci.naje, hello.naje, square.naje.

The strangest thing to me is that at the beginning of the code, it reads: "Naje is a minimalistic assembler for the Nga instruction set. It provides:  * Two passes: assemble, then resolve lables"
...so, what I've implemented here seems like it shouldn't be a *new* feature..!