### PR TITLE
fix reference counting for debug output purposes

### DIFF
--- a/Naje.md
+++ b/Naje.md
@@ -429,7 +429,7 @@ void najeAssemble(char *source) {
         najeData(1, -9999);
       } else {
         najeData(-1, najeLookup((char *) token+1));
-        najeRefCount[najeLookupPtr((char *) token)]++;
+        najeRefCount[najeLookupPtr((char *) token+1)]++;
       }
     } else {
       najeData(0, atoi(token));


### PR DESCRIPTION
Noticed a small bug; this change, introduced, will fix reference counting.

ex: "over^2.1 rot^4.1 fib^6.1 fib<1>^10.1 main^17.0" as debug output when compiling fibonacci.naje.